### PR TITLE
Remove logging config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@
 ### Added
 
 - Added `Describe` method to `Config` interface. [#8](https://github.com/go-nacelle/config/pull/8)
+- Added `WithLogger` and `WithMaskedKeys` to replace `NewLoggingConfig`. [#11](https://github.com/go-nacelle/config/pull/11)
 
 ### Removed
 
 - Removed mocks package. [#9](https://github.com/go-nacelle/config/pull/9)
 - Removed `MustLoad` from `Config` interface. [#10](https://github.com/go-nacelle/config/pull/10)
+- Removed `NewLoggingConfig`. [#11](https://github.com/go-nacelle/config/pull/11)
 
 ### Changed
 

--- a/config_options.go
+++ b/config_options.go
@@ -1,0 +1,31 @@
+package config
+
+type configOptions struct {
+	logger     Logger
+	maskedKeys []string
+}
+
+// ConfigOptionsFunc is a function used to configure instances of config.
+type ConfigOptionsFunc func(*configOptions)
+
+// WithLogger sets the Logger instance.
+func WithLogger(logger Logger) ConfigOptionsFunc {
+	return func(o *configOptions) { o.logger = logger }
+}
+
+// WithMaskedKeys sets the field names of values masked in log messages.
+func WithMaskedKeys(maskedKeys []string) ConfigOptionsFunc {
+	return func(o *configOptions) { o.maskedKeys = maskedKeys }
+}
+
+func getConfigOptions(configs []ConfigOptionsFunc) *configOptions {
+	options := &configOptions{
+		logger: &nilLogger{},
+	}
+
+	for _, f := range configs {
+		f(options)
+	}
+
+	return options
+}


### PR DESCRIPTION
Replace the logging config implementation by moving the behavior into the default implementation exposed via functional arguments.