### PR TITLE
Add support for setting, retrieving, and loading a config with contexts.

### DIFF
--- a/contexts.go
+++ b/contexts.go
@@ -9,7 +9,7 @@ type configKeyType struct{}
 
 var configKey = configKeyType{}
 
-func WithContext(ctx context.Context, cfg *Config) context.Context {
+func WithConfig(ctx context.Context, cfg *Config) context.Context {
 	return context.WithValue(ctx, configKey, cfg)
 }
 

--- a/contexts.go
+++ b/contexts.go
@@ -1,0 +1,30 @@
+package config
+
+import (
+	"context"
+	"fmt"
+)
+
+type configKeyType struct{}
+
+var configKey = configKeyType{}
+
+func WithContext(ctx context.Context, cfg *Config) context.Context {
+	return context.WithValue(ctx, configKey, cfg)
+}
+
+func FromContext(ctx context.Context) *Config {
+	if v, ok := ctx.Value(configKey).(*Config); ok {
+		return v
+	}
+	return nil
+}
+
+func LoadFromContext(ctx context.Context, target interface{}, modifiers ...TagModifier) error {
+	cfg := FromContext(ctx)
+	if cfg == nil {
+		return fmt.Errorf("config loader not found in context")
+	}
+
+	return cfg.Load(target, modifiers...)
+}

--- a/contexts_test.go
+++ b/contexts_test.go
@@ -19,7 +19,7 @@ func TestWithAndFromContext(t *testing.T) {
 		}))
 
 		ctx := context.Background()
-		ctx = WithContext(ctx, cfg)
+		ctx = WithConfig(ctx, cfg)
 
 		ctxCfg := FromContext(ctx)
 		require.NotNil(t, ctxCfg)
@@ -53,7 +53,7 @@ func TestLoadFromContext(t *testing.T) {
 		}))
 
 		ctx := context.Background()
-		ctx = WithContext(ctx, cfg)
+		ctx = WithConfig(ctx, cfg)
 
 		loadCfg := &TestConfig{}
 		err := LoadFromContext(ctx, loadCfg)
@@ -66,7 +66,7 @@ func TestLoadFromContext(t *testing.T) {
 		}))
 
 		ctx := context.Background()
-		ctx = WithContext(ctx, cfg)
+		ctx = WithConfig(ctx, cfg)
 
 		loadCfg := &TestConfig{}
 		err := LoadFromContext(ctx, loadCfg, NewEnvTagPrefixer("tag"))

--- a/contexts_test.go
+++ b/contexts_test.go
@@ -1,0 +1,76 @@
+package config
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithAndFromContext(t *testing.T) {
+	t.Run("from context without value", func(t *testing.T) {
+		ctx := context.Background()
+		assert.Nil(t, FromContext(ctx))
+	})
+	t.Run("from context that has value", func(t *testing.T) {
+		cfg := NewConfig(NewFakeSourcer("app", map[string]string{
+			"APP_FOO": "bar",
+		}))
+
+		ctx := context.Background()
+		ctx = WithContext(ctx, cfg)
+
+		ctxCfg := FromContext(ctx)
+		require.NotNil(t, ctxCfg)
+
+		type TestConfig struct {
+			Foo string `env:"foo"`
+		}
+
+		loadCfg := &TestConfig{}
+		err := ctxCfg.Load(loadCfg)
+		assert.NoError(t, err)
+		assert.Equal(t, "bar", loadCfg.Foo)
+	})
+}
+
+func TestLoadFromContext(t *testing.T) {
+	type TestConfig struct {
+		Foo string `env:"foo"`
+	}
+
+	t.Run("no config in context", func(t *testing.T) {
+		ctx := context.Background()
+
+		loadCfg := &TestConfig{}
+		err := LoadFromContext(ctx, loadCfg)
+		assert.EqualError(t, err, "config loader not found in context")
+	})
+	t.Run("loads from context", func(t *testing.T) {
+		cfg := NewConfig(NewFakeSourcer("app", map[string]string{
+			"APP_FOO": "bar",
+		}))
+
+		ctx := context.Background()
+		ctx = WithContext(ctx, cfg)
+
+		loadCfg := &TestConfig{}
+		err := LoadFromContext(ctx, loadCfg)
+		assert.NoError(t, err)
+		assert.Equal(t, "bar", loadCfg.Foo)
+	})
+	t.Run("loads from context with tag modifiers", func(t *testing.T) {
+		cfg := NewConfig(NewFakeSourcer("app", map[string]string{
+			"APP_TAG_FOO": "bar",
+		}))
+
+		ctx := context.Background()
+		ctx = WithContext(ctx, cfg)
+
+		loadCfg := &TestConfig{}
+		err := LoadFromContext(ctx, loadCfg, NewEnvTagPrefixer("tag"))
+		assert.NoError(t, err)
+		assert.Equal(t, "bar", loadCfg.Foo)
+	})
+}


### PR DESCRIPTION
I added a few functions to make it possible to work with `*Config`s using a `context.Context` instead of using the service container directly. It follows the convention of `WithContext` to include the `*Config` in the context, then `FromContext` to retrieve it.

I also added a `LoadFromContext` function that mirrors the `Load` function, but pulls the `*Config` from the context so users don't need to do that themselves.

I'll be interested to hear your feedback!