### PR TITLE
Make dumping source values on error an option, disabled by default.

### DIFF
--- a/config.go
+++ b/config.go
@@ -32,6 +32,8 @@ type Config struct {
 	sourcer    Sourcer
 	logger     Logger
 	maskedKeys []string
+
+	sourceDumpOnErr bool
 }
 
 // NewConfig creates a config loader with the given sourcer.
@@ -42,6 +44,8 @@ func NewConfig(sourcer Sourcer, configs ...ConfigOptionsFunc) *Config {
 		sourcer:    sourcer,
 		logger:     options.logger,
 		maskedKeys: options.maskedKeys,
+
+		sourceDumpOnErr: options.sourceDumpOnErr,
 	}
 }
 
@@ -68,7 +72,9 @@ func (c *Config) Load(target interface{}, modifiers ...TagModifier) error {
 			targetFields[i].Field.Set(sourceFields[i].Field)
 		}
 	} else {
-		c.dumpSource()
+		if c.sourceDumpOnErr {
+			c.dumpSource()
+		}
 		return newLoadError(errors)
 	}
 

--- a/config_options.go
+++ b/config_options.go
@@ -1,8 +1,9 @@
 package config
 
 type configOptions struct {
-	logger     Logger
-	maskedKeys []string
+	logger          Logger
+	maskedKeys      []string
+	sourceDumpOnErr bool
 }
 
 // ConfigOptionsFunc is a function used to configure instances of config.
@@ -16,6 +17,13 @@ func WithLogger(logger Logger) ConfigOptionsFunc {
 // WithMaskedKeys sets the field names of values masked in log messages.
 func WithMaskedKeys(maskedKeys []string) ConfigOptionsFunc {
 	return func(o *configOptions) { o.maskedKeys = maskedKeys }
+}
+
+// WithSourceDumpOnError sets whether the config source will be dumped on a
+// config load error or not. It can be useful for troubleshooting, but unless
+// other options are set correctly it could lead to secrets being logged.
+func WithSourceDumpOnError(sourceDumpOnErr bool) ConfigOptionsFunc {
+	return func(o *configOptions) { o.sourceDumpOnErr = sourceDumpOnErr }
 }
 
 func getConfigOptions(configs []ConfigOptionsFunc) *configOptions {


### PR DESCRIPTION
Right now, the Config struct will log the source values used to load a config if it encounters an error while loading. This is great for troubleshooting but can easily log secrets if using an env sourcer and running on a platform that sets a number of env secrets by default.

This turns dumping that into an option and keeps it off by default, so users need to opt-into logging that.

An additional thought I had while implementing this is that there could also be an `allowedKeys` corollary, where you can choose which keys are safe rather than which keys are unsafe to log.